### PR TITLE
Fix duplicate MultiStepper update

### DIFF
--- a/src/Stepper_Config.cpp
+++ b/src/Stepper_Config.cpp
@@ -83,21 +83,6 @@ void stopAllSteppers() {
 }
 
 void stepperISR() {
-    // ===== Koordinierte MultiStepper-Bewegung =====
-    if (multiMoveActive) {
-        multiStepperGroup.runSpeedToPosition();
-        bool stillMoving = false;
-        for (uint8_t i = 0; i < 6; i++) {
-            if (motors[i].distanceToGo() != 0) {
-                stillMoving = true;
-                break;
-            }
-        }
-        if (!stillMoving) {
-            multiMoveActive = false;
-        }
-    }
-
     // ===== Einzelachsen (JointMode) – STEP-Pulse =====
     unsigned long now = micros();
     for (uint8_t i = 0; i < 6; i++) {

--- a/src/Stepper_Config.h
+++ b/src/Stepper_Config.h
@@ -42,10 +42,10 @@ bool isMultiMoveActive();
 void stopAllSteppers();
 
 /**
- * @brief  Interrupt-Service-Routine für STEP-Puls-Generierung (Multi & JointMode).
+ * @brief  Interrupt-Service-Routine für STEP-Puls-Generierung im JointMode.
  *
- *   - Koordiniert via multiStepperGroup.runSpeedToPosition()
  *   - Erzeugt Einzel-Achsen Pulse (JointMode) anhand targetSpeeds[] & stepInterval[].
+ *   - Koordinierte Bewegungen werden in updateAllSteppers() abgearbeitet.
  */
 void stepperISR();
 


### PR DESCRIPTION
## Summary
- avoid running coordinated motion from the interrupt
- run MultiStepper control only in `updateAllSteppers`
- update ISR documentation

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d50463f4832bbc234f7526baa9bb